### PR TITLE
Pull DB call bugfix into main

### DIFF
--- a/modules/Module.Infrastructure.BotAdministration.js
+++ b/modules/Module.Infrastructure.BotAdministration.js
@@ -103,7 +103,7 @@ const Module = new Augur.Module()
     parseParams: true,
     process: async (msg) => {
       u.clean(msg, 0);
-      return msg.guild.members.cache.map(m => db.User.new(Module, m.id));
+      return msg.guild.members.cache.map(m => db.User.new(m.id));
     },
     permissions: (msg) => Module.config.adminId.includes(msg.author.id)
   })
@@ -118,12 +118,12 @@ const Module = new Augur.Module()
       if (newMember.roles.cache.size > oldMember.roles.cache.size) {
         // Role added
         try {
-          await db.User.updateRoles(Module, newMember);
+          await db.User.updateRoles(newMember);
         } catch (error) { u.errorHandler(error, "Update Roles on Role Add"); }
       } else if (newMember.roles.cache.size < oldMember.roles.cache.size) {
         // Role removed
         try {
-          await db.User.updateRoles(Module, newMember);
+          await db.User.updateRoles(newMember);
         } catch (error) { u.errorHandler(error, "Update Roles on Role Remove"); }
       }
     }


### PR DESCRIPTION
Parts of the bot administration file were not updated to reflect the new database calls that do not requrie the module to be called in. This caused role updates to not be reflected properly, which was missed in testing. This resolves that issue