### PR TITLE
When someone joins the guild, don't send messages in mod logs

### DIFF
--- a/modules/Module.Infrastructure.Welcome.js
+++ b/modules/Module.Infrastructure.Welcome.js
@@ -86,8 +86,7 @@ const Module = new Augur.Module()
         embed.setTitle(member.displayName + " has joined the server.");
 
         db.User.new(member);
-      }
-      modLogs.send({ content: "User joined", embeds: [embed] });
+      } 
 
       if (!member.user.bot)
         //general.send(welcomeString);

--- a/utils/Utils.Database.js
+++ b/utils/Utils.Database.js
@@ -275,7 +275,7 @@ let DataBaseActions = {
         client = Module.client;
         if (!hasBeenInitialized) {
             con.connect(function (err) {
-                if (err) throw err;
+                if (err && !err.toString.indexOf("Cannot enqueue Handshake after already enqueuing a Handshake") > -1 ) throw err;
                 console.log("Connected to DataBase!");
             })
             hasBeenInitialized = true;

--- a/utils/Utils.RolesLogin.js
+++ b/utils/Utils.RolesLogin.js
@@ -8,7 +8,7 @@ let token = config.auxToken;
 const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
 
 // When the client is ready, run this code (only once)
-client.once('ready', () => {
+client.once('Mysterious Bot Entity is now online', () => {
 	console.log('Ready!');
 });
 


### PR DESCRIPTION
The admins wanted to have Dyno handle the logging needs of the server, so this functionality has been removed. there were also some minor stability improvements to Module.Infrastructure.Welcome.js