### PR TITLE
Remove bookmarking LARPer, Webhook, and TTRPGer messages

### DIFF
--- a/modules/Module.ContextMenu.Bookmark.js
+++ b/modules/Module.ContextMenu.Bookmark.js
@@ -2,18 +2,44 @@ const Augur = require("augurbot"),
     u = require("../utils/Utils.Generic");
 const snowflakes = require('../config/snowflakes.json');
 
-// Message context menu for bookmarking a message.
-
-async function sendBookmark(message, userToSendBookmarkTo) {
-    const embed = u.embed()
-        .setAuthor(message.member?.displayName || message.author?.username, message.author?.displayAvatarURL({ size: 16 }), message.url)
-        .setDescription(message.cleanContent)
-        .setColor(message.member?.displayColor)
-        .setTimestamp(message.createdAt);
-    await userToSendBookmarkTo.send({ embeds: [embed].concat(message.embeds), files: Array.from(message.attachments.values()) });
+/**
+ * Returns true if the member has a role that indicates they have access to redacted info
+ * @param {GuildMember} member 
+ * @returns {boolean}
+ */
+function memberHasSensativeData(member) {
+    if (!snowflakes.roles.SensativeDataHolders) return false
+    else if (!member || member == null || !member.roles) return true;
+    else return snowflakes.roles.SensativeDataHolders.some(r => (member.roles.cache.includes(r.id)))
 }
 
 
+
+
+
+// Message context menu for bookmarking a message.
+
+/**
+ * Sends a copy of any guild message to a user, so long as the permissions checks work
+ * @param {Message} message 
+ * @param {User} userToSendBookmarkTo 
+ * @returns 
+ */
+async function sendBookmark(message, userToSendBookmarkTo) {
+    if (memberHasSensativeData(message.member) && userToSendBookmarkTo != message.author) {
+        return false;
+    } else {
+        const embed = u.embed()
+            .setAuthor(message.member?.displayName || message.author?.username, message.author?.displayAvatarURL({ size: 16 }), message.url)
+            .setDescription(message.cleanContent)
+            .setColor(message.member?.displayColor)
+            .setTimestamp(message.createdAt);
+        await userToSendBookmarkTo.send({ embeds: [embed].concat(message.embeds), files: Array.from(message.attachments.values()) });
+        return true;
+    }
+}
+
+const response = "Looks like that user might have access to non-public information, and to protect the world maker's intellectual property and prevent accidental leaks from spreading, I can't bookmark that"
 const Module = new Augur.Module()
     .addInteractionCommand({
         name: "Bookmark",
@@ -24,7 +50,10 @@ const Module = new Augur.Module()
                 const message = await interaction.channel.messages.fetch(interaction.targetId);
                 if (message) {
                     await interaction.editReply({ content: "I'm sending you a DM!", ephemeral: true });
-                    await sendBookmark(message, interaction.user)
+                    let canSendMessage = await sendBookmark(message, interaction.user);
+                    if (!canSendMessage) {
+                        await interaction.editReply({ content: response, ephemeral: true });
+                    }
                 } else {
                     interaction.editReply({ content: "Against all odds, I couldn't find that message.", ephemeral: true });
                 }
@@ -37,7 +66,10 @@ const Module = new Augur.Module()
             return;
         } else {
             try {
-                await sendBookmark(reaction.message, user)
+                let canSendMessage = await sendBookmark(reaction.message, user)
+                if (!canSendMessage) {
+                    await user.send({ content: response, ephemeral: true });
+                }
             } catch (error) {
                 u.errorHandler(error);
             }

--- a/modules/Module.Infrastructure.BotAdministration.js
+++ b/modules/Module.Infrastructure.BotAdministration.js
@@ -111,8 +111,7 @@ const Module = new Augur.Module()
   .addEvent("ready", () => {
     //When the bot is fully online, fetch all the discord members, since it will only autofetch for small servers and we want them all.
     Module.client.guilds.cache.get(snowflakes.guilds.PrimaryServer).members.fetch();
-    //Connect to the DB as well, and set up the DB.utils file
-    db.init(Module);
+    
   }).addEvent("guildMemberUpdate", async (oldMember, newMember) => {
     if (newMember.guild.id == snowflakes.guilds.PrimaryServer) {
       if (newMember.roles.cache.size > oldMember.roles.cache.size) {
@@ -130,9 +129,11 @@ const Module = new Augur.Module()
   })
   //each time this module is loaded, update the module.config snowflakes.
   .setInit(async (reload) => {
+    //Connect to the DB as well, and set up the DB.utils file
+    db.init(Module);
     try {
       if (!reload) {
-        u.errorLog.send({ embeds: [u.embed().setDescription("Bot is ready!")] });
+        u.errorLog.send({ embeds: [u.embed().setColor("BLUE").setDescription("Bot is ready!")] });
       }
       let snowflakes = require("../config/snowflakes.json");
       Module.config.channels = snowflakes.channels;


### PR DESCRIPTION
This removes the abilty for users to bookmark messages that are not their own, if the message was sent by someone with a role specified in config/snowflakes.roles.SensativeDataHolders, to prevent the accidental spread of leaked data or bot aided collection of semi-redacted or redacted data.