### PR TITLE
Remove doubled up bolding from cake day messages

### DIFF
--- a/modules/Module.CommandInteraction.CakeDays.js
+++ b/modules/Module.CommandInteraction.CakeDays.js
@@ -47,7 +47,7 @@ async function testcakeOrJoinDays(guild) {
                     if (join && (join.month() == curDate.month()) && (join.date() == curDate.date()) && (join.year() < curDate.year())) {
                         let years = curDate.year() - join.year();
                         try {
-                            sendString = ` **They have been part of the server for ${years > 0 ? years : 1} ${(years > 1 ? "years" : "year")}! Glad you're with us!`;
+                            sendString = ` They have been part of the server for ${years > 0 ? years : 1} ${(years > 1 ? "years" : "year")}! Glad you're with us!`;
 
                         } catch (e) { u.errorHandler(e, "Announce Cake Day Error"); continue; }
                     }


### PR DESCRIPTION
Usernames are being bolded separately, removed asterisks were causing formatting issues. See below
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/28538707/161264316-1bd9f5ea-a3ef-4c73-b524-67b7003390b2.png">
