### PR TITLE
Remove valentines; Removed anonymous images

### DIFF
--- a/modules/Module.CommandInteraction.Silly.js
+++ b/modules/Module.CommandInteraction.Silly.js
@@ -75,7 +75,7 @@ async function composite(msg, suffix, compositeType, overrideImage) {
         mode: compositeType || Jimp.BLEND_MULTIPLY
 
       })
-      await msg.channel.send({ files: [await av.getBufferAsync(Jimp.MIME_PNG)] });
+      await msg.channel.send({content: `<@msg.author.id> created:`, files: [await av.getBufferAsync(Jimp.MIME_PNG)] });
     } catch (error) {
       msg.reply("I couldn't use that image! Make sure its a PNG, JPG, or JPEG.");
     }
@@ -93,7 +93,7 @@ const Module = new Augur.Module()
     process: async (msg) => {
       try {
         const canvas = await popart(msg, [{ apply: "spin", params: [60] }]);
-        if (canvas) await msg.channel.send({ files: [await canvas.getBufferAsync(Jimp.MIME_JPEG)] });
+        if (canvas) await msg.channel.send({content: `<@msg.author.id> created:`, files: [await canvas.getBufferAsync(Jimp.MIME_JPEG)] });
       } catch (e) { u.errorHandler(e, msg); }
 
     }
@@ -113,7 +113,7 @@ const Module = new Augur.Module()
           .setAuthor(name)
           .setDescription(u.escapeText(name) + "'s Avatar")
           .setImage(msg.member.displayAvatarURL({ size: 512, dynamic: true }));
-        msg.channel.send({ embeds: [embed] });
+        msg.channel.send({content: `<@msg.author.id> created:`, embeds: [embed] });
       } catch (error) { u.errorHandler(error, msg); }
     },
   })
@@ -142,7 +142,7 @@ const Module = new Augur.Module()
             { apply: "hue", params: [235] }         // { apply: "hue", params: [227] }
           ]);
 
-          await msg.channel.send({ files: [await av.getBufferAsync(Jimp.MIME_PNG)] });
+          await msg.channel.send({content: `<@msg.author.id> created:`, files: [await av.getBufferAsync(Jimp.MIME_PNG)] });
         } catch (error) {
           msg.reply("I couldn't use that image! Make sure its a PNG, JPG, or JPEG.");
         }
@@ -181,7 +181,7 @@ const Module = new Augur.Module()
           image.color([
             { apply: "hue", params: [color] }
           ]);
-          await msg.channel.send({ files: [await image.getBufferAsync(Jimp.MIME_PNG)] });
+          await msg.channel.send({content: `<@msg.author.id> created:`, files: [await image.getBufferAsync(Jimp.MIME_PNG)] });
         } catch (error) {
           msg.reply("I couldn't use that image! Make sure its a PNG, JPG, or JPEG.");
         }
@@ -215,12 +215,12 @@ const Module = new Augur.Module()
 
         canvas.blit(avatar, 120, 0);
 
-        await msg.channel.send({ files: [await canvas.getBufferAsync(Jimp.MIME_PNG)] });
+        await msg.channel.send({content: `<@msg.author.id> created:`, files: [await canvas.getBufferAsync(Jimp.MIME_PNG)] });
 
       } catch (e) { u.errorHandler(e, msg); }
     }
   })
-  .addCommand({
+  /*.addCommand({
     name: "valentines",
     description: "Show it off.",
     category: "Silly",
@@ -242,7 +242,7 @@ const Module = new Augur.Module()
 
       } catch (e) { u.errorHandler(e, msg); }
     }
-  })
+  })*/
   .addCommand({
     name: "greyscale",
     description: "Greyscale an Avatar",
@@ -264,7 +264,7 @@ const Module = new Augur.Module()
         try {
           let av = await Jimp.read(target);
           av.color([{ apply: "desaturate", params: [100] }]);
-          await msg.channel.send({ files: [await av.getBufferAsync(Jimp.MIME_PNG)] });
+          await msg.channel.send({content: `<@msg.author.id> created:`, files: [await av.getBufferAsync(Jimp.MIME_PNG)] });
         } catch (error) {
           msg.reply("I couldn't use that image! Make sure its a PNG, JPG, or JPEG.");
         }
@@ -291,7 +291,7 @@ const Module = new Augur.Module()
         try {
           let av = await Jimp.read(target);
           av.normalize();
-          await msg.channel.send({ files: [await av.getBufferAsync(Jimp.MIME_PNG)] });
+          await msg.channel.send({content: `<@msg.author.id> created:`, files: [await av.getBufferAsync(Jimp.MIME_PNG)] });
         } catch (error) {
           msg.reply("I couldn't use that image! Make sure its a PNG, JPG, or JPEG.");
         }
@@ -318,7 +318,7 @@ const Module = new Augur.Module()
         try {
           let av = await Jimp.read(target);
           av.blur(20)
-          await msg.channel.send({ files: [await av.getBufferAsync(Jimp.MIME_PNG)] });
+          await msg.channel.send({content: `<@msg.author.id> created:`, files: [await av.getBufferAsync(Jimp.MIME_PNG)] });
         } catch (error) {
           msg.reply("I couldn't use that image! Make sure its a PNG, JPG, or JPEG.");
         }
@@ -345,7 +345,7 @@ const Module = new Augur.Module()
         try {
           let av = await Jimp.read(target);
           av.pixelate(20)
-          await msg.channel.send({ files: [await av.getBufferAsync(Jimp.MIME_PNG)] });
+          await msg.channel.send({content: `<@msg.author.id> created:`, files: [await av.getBufferAsync(Jimp.MIME_PNG)] });
         } catch (error) {
           msg.reply("I couldn't use that image! Make sure its a PNG, JPG, or JPEG.");
         }
@@ -372,7 +372,7 @@ const Module = new Augur.Module()
         try {
           let av = await Jimp.read(target);
           av.sepia()
-          await msg.channel.send({ files: [await av.getBufferAsync(Jimp.MIME_PNG)] });
+          await msg.channel.send({content: `<@msg.author.id> created:`, files: [await av.getBufferAsync(Jimp.MIME_PNG)] });
         } catch (error) {
           msg.reply("I couldn't use that image! Make sure its a PNG, JPG, or JPEG.");
         }
@@ -406,7 +406,7 @@ const Module = new Augur.Module()
               img.setPixelColor(Jimp.rgbaToInt(255 - r, 255 - g, 255 - b, a), x, y);
             }
           }
-          await msg.channel.send({ files: [await img.getBufferAsync(Jimp.MIME_PNG)] });
+          await msg.channel.send({content: `<@msg.author.id> created:`, files: [await img.getBufferAsync(Jimp.MIME_PNG)] });
         } catch (error) {
           msg.reply("I couldn't use that image! Make sure its a PNG, JPG, or JPEG.");
         }
@@ -440,7 +440,7 @@ const Module = new Augur.Module()
 
         canvas.blit(avatar, 120, 0);
 
-        await msg.channel.send({ files: [await canvas.getBufferAsync(Jimp.MIME_PNG)] });
+        await msg.channel.send({content: `<@msg.author.id> created:`, files: [await canvas.getBufferAsync(Jimp.MIME_PNG)] });
 
       } catch (e) { u.errorHandler(e, msg); }
     }
@@ -458,7 +458,7 @@ const Module = new Augur.Module()
         target.resize(350, 350);
         target.mask(mask);
         image.blit(target, 1050, 75);
-        await msg.channel.send({ files: [await image.getBufferAsync(Jimp.MIME_PNG)] });
+        await msg.channel.send({content: `<@msg.author.id> created:`, files: [await image.getBufferAsync(Jimp.MIME_PNG)] });
 
       } catch (e) { u.errorHandler(e, msg); }
     }
@@ -473,7 +473,7 @@ const Module = new Augur.Module()
           { apply: "desaturate", params: [100] },
           { apply: "saturate", params: [50] }
         ]);
-        if (canvas) await msg.channel.send({ files: [await canvas.getBufferAsync(Jimp.MIME_JPEG)] });
+        if (canvas) await msg.channel.send({content: `<@msg.author.id> created:`, files: [await canvas.getBufferAsync(Jimp.MIME_JPEG)] });
       } catch (e) { u.errorHandler(e, msg); }
 
     }


### PR DESCRIPTION
If a user invoked a photo creation command, then deleted the invocation command, it could appear as if the bot or a bot admin sent it of their own accord. this is undesirable behavior, as inappropriate images could be anonymously generated. this has been patched to ping